### PR TITLE
Remove stickyfilljs dependency

### DIFF
--- a/lib/common-js-modules.js
+++ b/lib/common-js-modules.js
@@ -1,5 +1,4 @@
 require('intersection-observer');
-const stickyPolyfill = require('stickyfilljs');
 const smoothScrollPolyfill = require('smoothscroll-polyfill').polyfill;
 
-module.exports = { smoothScrollPolyfill, stickyPolyfill };
+module.exports = { smoothScrollPolyfill };

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "^23.3.1",
     "@vaadin/vaadin-themable-mixin": "^23.3.1",
     "intersection-observer": "^0.10.0",
-    "smoothscroll-polyfill": "^0.4.4",
-    "stickyfilljs": "^2.1.0"
+    "smoothscroll-polyfill": "^0.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/vcf-anchor-nav.js
+++ b/src/vcf-anchor-nav.js
@@ -1,7 +1,7 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin';
-import { smoothScrollPolyfill, stickyPolyfill } from '../lib/common-js-modules.esm';
+import { smoothScrollPolyfill } from '../lib/common-js-modules.esm';
 import { ResizeObserver } from '@juggle/resize-observer';
 import '@vaadin/tabs/vaadin-tabs';
 import '@vaadin/tabs/vaadin-tab';
@@ -244,9 +244,8 @@ export class AnchorNavElement extends ElementMixin(ThemableMixin(PolymerElement)
   ready() {
     super.ready();
     this._verticalTabs = false;
-    // Add polyfills
+    // Add polyfill
     smoothScrollPolyfill();
-    stickyPolyfill.add(this.$.tabs);
     // Init observers
     this._initTabsStuckAttribute();
     this._initWindowResizeListener();


### PR DESCRIPTION
Remove `stickyfilljs` dependency since Internet Explorer is out of support. This has the added benefit that `vcf-anchor-nav` is not flagged by dependency scanners anymore (`stickyfilljs` depends on a vulnerable version of jQuery, and is unmaintained), helping adoption in enterprise environments. 

This pull request does not update the `common-js-module.*` files, I assume they are autogenerated? Otherwise please let me know what extra steps are required. 

Fixes #11 